### PR TITLE
cropduster upgrade: make compatible with cropduster4

### DIFF
--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -10,6 +10,8 @@ import operator, sys
 from threading import local
 from weakref import WeakValueDictionary
 
+from cropduster.fields import CropDusterImageFieldFile
+
 from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist
@@ -75,6 +77,8 @@ class VersionAdapter(object):
             elif isinstance(related, (models.Manager, QuerySet)):
                 for related_obj in related.all():
                     yield related_obj
+            elif isinstance(related, CropDusterImageFieldFile):
+                continue  # incompatible with cropduster4 fields
             elif related is not None:
                 raise TypeError, "Cannot follow the relationship %r. Expected a model or QuerySet, found %r" % (relationship, related)
     


### PR DESCRIPTION
Apparently reversion can't work with the new cropduster field objects,
so we're going to have to ignore them in this context. This means that
reversion history will not contain cropduster images. We're hoping this
will not be a big deal.

There might be a nicer way to have reversion exclude these fields,
but I didn't easily see one, and didn't think it would be worth opening
an issue since we're on a fork that has not been kept up to date. And
this change seemed less-bad than doing some kind of monkey-patching.
